### PR TITLE
fix build with newer GCC

### DIFF
--- a/lib/cpp/antlr/CharScanner.hpp
+++ b/lib/cpp/antlr/CharScanner.hpp
@@ -10,6 +10,8 @@
 
 #include <antlr/config.hpp>
 
+#include <cstdio>
+#include <cstring>
 #include <map>
 
 #ifdef HAS_NOT_CCTYPE_H


### PR DESCRIPTION
Since it's currently difficult for `nco` to migrate to ANTLR4, I thought it would be a good idea to upstream the fix we are using in Homebrew (https://github.com/Homebrew/homebrew-core/pull/103967) to this repo so that ANTLR2 can be built with newer GCC.  It would be great if a tagged release could be made with this fix incorporated for downstream package managers as well, as several of the existing links for patched versions of ANTLR2 are flaky or completely broken.